### PR TITLE
Remove hard-coded API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # Jenius
 PRO192 AI Agent
+
+## Setup
+
+Before running the application, set the environment variable `GENAI_API_KEY` with your API key:
+
+```bash
+export GENAI_API_KEY=your_api_key_here
+```
+
+Run the application using Maven:
+
+```bash
+mvn exec:java
+```

--- a/src/main/java/controller/JeniusController.java
+++ b/src/main/java/controller/JeniusController.java
@@ -12,7 +12,10 @@ public class JeniusController {
     private final ConsoleView view;
 
     public JeniusController() throws IOException {
-        String apiKey = "AIzaSyCSeJkWCGwwX-BABEMS7yYpkVSZMBqhJ-U";
+        String apiKey = System.getenv("GENAI_API_KEY");
+        if (apiKey == null || apiKey.isEmpty()) {
+            throw new IllegalStateException("GENAI_API_KEY environment variable is not set");
+        }
         this.model = new GenAIModel(apiKey);
         this.view = new ConsoleView();
     }


### PR DESCRIPTION
## Summary
- use `GENAI_API_KEY` environment variable in `JeniusController`
- add setup instructions for environment variable in README

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6870ed2359308329a7f8bed522e6de12