### PR TITLE
Load API key from environment

### DIFF
--- a/src/main/java/controller/JeniusController.java
+++ b/src/main/java/controller/JeniusController.java
@@ -18,7 +18,7 @@ public class JeniusController {
     private final ConsoleView view;
 
     public JeniusController() throws IOException {
-        String apiKey = "AIzaSyCSeJkWCGwwX-BABEMS7yYpkVSZMBqhJ-U";
+        String apiKey = System.getenv("GENAI_API_KEY");
         if (apiKey == null || apiKey.isEmpty()) {
             throw new IllegalStateException("GENAI_API_KEY environment variable is not set");
         }


### PR DESCRIPTION
## Summary
- load the API key from the `GENAI_API_KEY` environment variable

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6871154fc0548329a74ff28bc8253788