### PR TITLE
Add persistent memory and workflow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,11 @@
             <artifactId>google-genai</artifactId>
             <version>1.7.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/controller/JeniusController.java
+++ b/src/main/java/controller/JeniusController.java
@@ -6,6 +6,8 @@ import com.google.genai.types.FunctionCall;
 import com.google.genai.types.GenerateContentResponse;
 import com.google.genai.types.Part;
 import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
 import java.text.Normalizer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -50,46 +52,76 @@ public class JeniusController {
                 return;
             }
 
-            model.history.addMessage("User", input);
-            GenerateContentResponse response = model.generateResponse(input);
+            // explicit memory commands
+            if (normalized.startsWith("remember this for me") || normalized.startsWith("this is important")) {
+                String fact = input.substring(input.indexOf(" ") + 1).replaceFirst("(?i)remember this for me", "").replaceFirst("(?i)this is important", "").replaceFirst(":" , "").trim();
+                String analysis = model.saveToMemory(fact);
+                model.history.addMessage("User", input);
+                model.history.addMessage("Jenius", analysis);
+                view.displayResponse(analysis);
+                return;
+            }
 
-            if (response.automaticFunctionCallingHistory().isPresent()) {
-                for (Content c : response.automaticFunctionCallingHistory().get()) {
-                    if (c.parts().isPresent()) {
-                        for (Part p : c.parts().get()) {
-                            if (p.functionCall().isPresent()) {
-                                FunctionCall fc = p.functionCall().get();
-                                String name = fc.name().orElse("");
-                                String arg = fc.args().orElse(Map.of()).values().stream()
-                                        .findFirst()
-                                        .map(Object::toString)
-                                        .orElse("");
-                                String result = executeFunction(name, arg);
-                                if (result != null) {
-                                    model.history.addMessage("Jenius", result);
-                                    view.displayResponse(result);
-                                    return;
+            model.saveImplicitFactFromMessage(input);
+            model.history.addMessage("User", input);
+
+            String next = input;
+            while (true) {
+                GenerateContentResponse response = model.generateResponse(next);
+                next = null;
+
+                if (response.automaticFunctionCallingHistory().isPresent()) {
+                    boolean executed = false;
+                    for (Content c : response.automaticFunctionCallingHistory().get()) {
+                        if (c.parts().isPresent()) {
+                            for (Part p : c.parts().get()) {
+                                if (p.functionCall().isPresent()) {
+                                    FunctionCall fc = p.functionCall().get();
+                                    String name = fc.name().orElse("");
+                                    Map<String, Object> args = fc.args().orElse(Map.of());
+                                    String result = executeFunction(name, args);
+                                    if (result != null) {
+                                        executed = true;
+                                        model.history.addMessage("Jenius", result);
+                                        next = result;
+                                    }
                                 }
                             }
                         }
                     }
+                    if (executed) {
+                        continue;
+                    }
                 }
-            }
 
-            String text = response.text();
-            model.history.addMessage("Jenius", text);
-            view.displayResponse(text);
+                String text = response.text();
+                model.history.addMessage("Jenius", text);
+                view.displayResponse(text);
+                break;
+            }
         } catch (Exception e) {
             view.displayError("Error processing command: " + e.getMessage());
         }
     }
 
-    private String executeFunction(String name, String arg) {
+    private String executeFunction(String name, Map<String, Object> args) {
         switch (name) {
-            case "summarizeFile":
-                return model.summarizeFile(arg);
-            case "generateQuestions":
-                return model.generateQuestions(arg);
+            case "summarizeFile": {
+                String path = args.values().stream().findFirst().map(Object::toString).orElse("");
+                return model.summarizeFile(path);
+            }
+            case "createQuiz": {
+                List<Object> vals = new ArrayList<>(args.values());
+                String ctx = vals.size() > 0 ? vals.get(0).toString() : "";
+                int count = vals.size() > 1 ? Integer.parseInt(vals.get(1).toString()) : 5;
+                return model.createQuiz(ctx, count);
+            }
+            case "saveToMemory": {
+                String fact = args.values().stream().findFirst().map(Object::toString).orElse("");
+                return model.saveToMemory(fact);
+            }
+            case "proactiveAnalysis":
+                return model.proactiveAnalysis();
             default:
                 return null;
         }

--- a/src/main/java/model/GenAIModel.java
+++ b/src/main/java/model/GenAIModel.java
@@ -11,16 +11,22 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.stream.Collectors;
+
+// memory handling
+import java.util.Optional;
 
 public class GenAIModel {
 
     private final Client client;
     public final ConversationHistory history;
+    private final MemoryManager memory;
     private static GenAIModel activeModel;
 
     public GenAIModel(String apiKey) {
         this.client = Client.builder().apiKey(apiKey).build();
         this.history = new ConversationHistory();
+        this.memory = new MemoryManager();
         activeModel = this;
     }
 
@@ -33,10 +39,11 @@ public class GenAIModel {
         return generateTaskResponse(prompt).text();
     }
 
-    public String generateQuestions(String input) {
-        String prompt = "Generate 5 multiple-choice questions based on " + input + " with 4 answer options each.";
+    public String createQuiz(String context, int questionCount) {
+        String prompt = "Create " + questionCount + " multiple-choice questions based on the following text:\n" + context;
         return generateTaskResponse(prompt).text();
     }
+
 
     public String summarizeFile(String path) {
         try {
@@ -44,6 +51,29 @@ public class GenAIModel {
             return summarizeContent(content);
         } catch (IOException e) {
             return "Error reading file: " + e.getMessage();
+        }
+    }
+
+    public String saveToMemory(String fact) {
+        memory.saveFact(fact);
+        return proactiveAnalysis();
+    }
+
+    public String proactiveAnalysis() {
+        String joined = memory.getFacts().stream().collect(Collectors.joining("\n"));
+        String prompt = "You are a research analyst AI. Find non-obvious connections between these facts about the user and explain them succinctly:\n" + joined;
+        return generateTaskResponse(prompt).text();
+    }
+
+    public String extractImportantFact(String message) {
+        String prompt = "From the following user statement, extract a short factual snippet that would help you understand the user better. If nothing new is learned, just return an empty string.\n" + message;
+        return generateTaskResponse(prompt).text().trim();
+    }
+
+    public void saveImplicitFactFromMessage(String message) {
+        String fact = extractImportantFact(message);
+        if (fact != null && !fact.isBlank()) {
+            saveToMemory(fact);
         }
     }
 
@@ -59,16 +89,30 @@ public class GenAIModel {
         return activeModel.summarizeFile(path);
     }
 
-    /**
-     * Static wrapper for generateQuestions that delegates to the active model
-     * instance.
-     */
-    public static String generateQuestionsStatic(String input) {
+    /** Static wrapper for createQuiz */
+    public static String createQuizStatic(String context, int questionCount) {
         if (activeModel == null) {
             throw new IllegalStateException("No active GenAIModel instance");
         }
-        return activeModel.generateQuestions(input);
+        return activeModel.createQuiz(context, questionCount);
     }
+
+    /** Static wrapper for saveToMemory */
+    public static String saveToMemoryStatic(String fact) {
+        if (activeModel == null) {
+            throw new IllegalStateException("No active GenAIModel instance");
+        }
+        return activeModel.saveToMemory(fact);
+    }
+
+    /** Static wrapper for proactiveAnalysis */
+    public static String proactiveAnalysisStatic() {
+        if (activeModel == null) {
+            throw new IllegalStateException("No active GenAIModel instance");
+        }
+        return activeModel.proactiveAnalysis();
+    }
+
 
     public GenerateContentResponse generateResponse(String currentPrompt) {
         try {
@@ -77,7 +121,9 @@ public class GenAIModel {
             Tool tool = Tool.builder()
                     .functions(List.of(
                             GenAIModel.class.getMethod("summarizeFileStatic", String.class),
-                            GenAIModel.class.getMethod("generateQuestionsStatic", String.class)
+                            GenAIModel.class.getMethod("createQuizStatic", String.class, int.class),
+                            GenAIModel.class.getMethod("saveToMemoryStatic", String.class),
+                            GenAIModel.class.getMethod("proactiveAnalysisStatic")
                     ))
                     .build();
 

--- a/src/main/java/model/MemoryManager.java
+++ b/src/main/java/model/MemoryManager.java
@@ -1,0 +1,54 @@
+package model;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.lang.reflect.Type;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MemoryManager {
+    private static final Path MEMORY_PATH = Path.of("memory.json");
+    private final Gson gson = new Gson();
+    private List<String> facts;
+
+    public MemoryManager() {
+        load();
+    }
+
+    private void load() {
+        try {
+            if (Files.exists(MEMORY_PATH)) {
+                try (Reader r = Files.newBufferedReader(MEMORY_PATH)) {
+                    Type listType = new TypeToken<List<String>>(){}.getType();
+                    facts = gson.fromJson(r, listType);
+                }
+            }
+        } catch (IOException e) {
+            facts = new ArrayList<>();
+        }
+        if (facts == null) {
+            facts = new ArrayList<>();
+        }
+    }
+
+    public synchronized void saveFact(String fact) {
+        facts.add(fact);
+        persist();
+    }
+
+    public synchronized List<String> getFacts() {
+        return new ArrayList<>(facts);
+    }
+
+    private void persist() {
+        try (Writer w = Files.newBufferedWriter(MEMORY_PATH)) {
+            gson.toJson(facts, w);
+        } catch (IOException ignored) {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `MemoryManager` for persistent `memory.json` facts
- expand `GenAIModel` with memory functions and tool registration
- update `JeniusController` for explicit memory commands and multi-step function workflows
- include Gson dependency for JSON persistence

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68750d9cd4c08329977d280f698f9dd0