### PR TITLE
Enable AI-driven note operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ mvn exec:java
 
 ## Notes Management
 
-Use the following commands inside the application:
+Use natural language to ask Jenius to remember something or delete a note.
+The assistant will automatically generate a short title for each note.
 
-- `add-note <title> <content>` – create a new note.
-- `list-notes` – display all notes.
-- `delete-note <title>` – remove a note by title.
+- `list-notes` – display all notes with their numeric IDs. Use these IDs when asking to delete or generate questions from a note.
+You can request actions like "Xóa note 2" (delete note 2) or "Tạo câu hỏi từ note 1" and the AI will call the appropriate functions.

--- a/src/main/java/controller/JeniusController.java
+++ b/src/main/java/controller/JeniusController.java
@@ -11,6 +11,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import model.GenAIModel;
 import model.NotesManager;
+import model.NoteFunctions;
 import view.ConsoleView;
 
 public class JeniusController {
@@ -27,6 +28,7 @@ public class JeniusController {
         this.model = new GenAIModel(apiKey);
         this.view = new ConsoleView();
         this.notesManager = new NotesManager();
+        NoteFunctions.init(this.notesManager, this.model);
     }
 
     public void start() {
@@ -48,31 +50,8 @@ public class JeniusController {
         try {
             String normalized = normalize(input).toLowerCase();
 
-            if (normalized.startsWith("add-note ")) {
-                String rest = input.substring(9);
-                String[] parts = rest.split(" ", 2);
-                if (parts.length < 2) {
-                    view.displayError("Usage: add-note <title> <content>");
-                } else {
-                    notesManager.addNote(parts[0], parts[1]);
-                    view.displayResponse("Note added");
-                }
-                return;
-            }
-
             if (normalized.equals("list-notes")) {
                 view.displayNotes(notesManager.getNotes());
-                return;
-            }
-
-            if (normalized.startsWith("delete-note ")) {
-                String title = input.substring(12).trim();
-                boolean removed = notesManager.deleteNote(title);
-                if (removed) {
-                    view.displayResponse("Note deleted");
-                } else {
-                    view.displayError("Note not found");
-                }
                 return;
             }
 
@@ -121,6 +100,14 @@ public class JeniusController {
                 return model.summarizeFile(arg);
             case "generateQuestions":
                 return model.generateQuestions(arg);
+            case "addNote":
+                return NoteFunctions.addNote(arg);
+            case "deleteNote":
+                return NoteFunctions.deleteNote(arg);
+            case "listNotes":
+                return NoteFunctions.listNotes();
+            case "generateQuestionsFromNote":
+                return NoteFunctions.generateQuestionsFromNote(arg);
             default:
                 return null;
         }

--- a/src/main/java/model/ConversationHistory.java
+++ b/src/main/java/model/ConversationHistory.java
@@ -17,8 +17,9 @@ public class ConversationHistory {
         Ensure all responses do not include the prefix ‘Jenius:’.
 
         [TOOL USAGE]
-        You have access to functions to summarize files and generate questions.
-        If a user's request can be fulfilled by a function (e.g., they mention a file path or ask to summarize), you MUST use that function.
+        You have access to functions to summarize files, manage notes and generate questions.
+        For note management you can add notes, delete notes by id, list notes and generate questions from a note.
+        If a user's request can be fulfilled by a function (e.g., they mention a file path, want to save a note or generate questions), you MUST use that function.
         Prioritize using a function over giving a conversational answer for tasks that match a tool's capability.
         
         Below is the chat history:\n""";

--- a/src/main/java/model/GenAIModel.java
+++ b/src/main/java/model/GenAIModel.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import model.NoteFunctions;
 
 public class GenAIModel {
 
@@ -77,7 +78,11 @@ public class GenAIModel {
             Tool tool = Tool.builder()
                     .functions(List.of(
                             GenAIModel.class.getMethod("summarizeFileStatic", String.class),
-                            GenAIModel.class.getMethod("generateQuestionsStatic", String.class)
+                            GenAIModel.class.getMethod("generateQuestionsStatic", String.class),
+                            NoteFunctions.class.getMethod("addNote", String.class),
+                            NoteFunctions.class.getMethod("deleteNote", String.class),
+                            NoteFunctions.class.getMethod("listNotes"),
+                            NoteFunctions.class.getMethod("generateQuestionsFromNote", String.class)
                     ))
                     .build();
 

--- a/src/main/java/model/NoteFunctions.java
+++ b/src/main/java/model/NoteFunctions.java
@@ -1,0 +1,84 @@
+package model;
+
+import java.util.List;
+
+/**
+ * Static helper functions for AI tool calling related to notes management.
+ */
+public class NoteFunctions {
+    private static NotesManager notesManager;
+    private static GenAIModel model;
+
+    /** Initialize with the active NotesManager and GenAIModel instances. */
+    public static void init(NotesManager manager, GenAIModel gm) {
+        notesManager = manager;
+        model = gm;
+    }
+
+    /**
+     * Add a new note. The title is generated automatically by summarizing the
+     * content. Returns the generated title.
+     */
+    public static String addNote(String content) {
+        if (notesManager == null || model == null) {
+            return "Notes system not initialized";
+        }
+        String title = model.summarizeContent(content);
+        // keep title short
+        if (title.length() > 60) {
+            title = title.substring(0, 60);
+        }
+        notesManager.addNote(title, content);
+        return "Added note '" + title + "'";
+    }
+
+    /** Delete a note by its 1-based index. */
+    public static String deleteNote(String indexStr) {
+        if (notesManager == null) {
+            return "Notes system not initialized";
+        }
+        try {
+            int idx = Integer.parseInt(indexStr.trim()) - 1;
+            Note removed = notesManager.deleteNote(idx);
+            if (removed != null) {
+                return "Deleted note '" + removed.getTitle() + "'";
+            }
+            return "Note not found";
+        } catch (NumberFormatException e) {
+            return "Invalid note id";
+        }
+    }
+
+    /** List all notes with their indices. */
+    public static String listNotes() {
+        if (notesManager == null) {
+            return "Notes system not initialized";
+        }
+        List<Note> notes = notesManager.getNotes();
+        if (notes.isEmpty()) {
+            return "No notes";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < notes.size(); i++) {
+            sb.append(i + 1).append(". ").append(notes.get(i).getTitle()).append("\n");
+        }
+        return sb.toString();
+    }
+
+    /** Generate questions from a note's content using its 1-based index. */
+    public static String generateQuestionsFromNote(String indexStr) {
+        if (notesManager == null || model == null) {
+            return "Notes system not initialized";
+        }
+        try {
+            int idx = Integer.parseInt(indexStr.trim()) - 1;
+            Note note = notesManager.getNote(idx);
+            if (note != null) {
+                return model.generateQuestions(note.getContent());
+            }
+            return "Note not found";
+        } catch (NumberFormatException e) {
+            return "Invalid note id";
+        }
+    }
+}

--- a/src/main/java/model/NotesManager.java
+++ b/src/main/java/model/NotesManager.java
@@ -10,11 +10,21 @@ public class NotesManager {
         notes.add(new Note(title, content));
     }
 
+    public Note getNote(int index) {
+        if (index >= 0 && index < notes.size()) {
+            return notes.get(index);
+        }
+        return null;
+    }
+
     public List<Note> getNotes() {
         return new ArrayList<>(notes);
     }
 
-    public boolean deleteNote(String title) {
-        return notes.removeIf(n -> n.getTitle().equalsIgnoreCase(title));
+    public Note deleteNote(int index) {
+        if (index >= 0 && index < notes.size()) {
+            return notes.remove(index);
+        }
+        return null;
     }
 }

--- a/src/main/java/view/ConsoleView.java
+++ b/src/main/java/view/ConsoleView.java
@@ -47,8 +47,9 @@ public class ConsoleView {
 
     public void displayNotes(List<Note> notes) {
         System.out.println("\n--- Notes ---");
-        for (Note note : notes) {
-            System.out.println(note.getTitle() + ": " + note.getContent());
+        for (int i = 0; i < notes.size(); i++) {
+            Note note = notes.get(i);
+            System.out.println((i + 1) + ") " + note.getTitle() + ": " + note.getContent());
         }
         System.out.println("--------------\n");
     }


### PR DESCRIPTION
## Summary
- add AI functions to manage notes: add, delete, list and generate questions
- expose these functions to the language model
- show note indices in console output
- update README for natural-language note commands

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_b_68765b5208b48329b84c4096ef0974a8