### PR TITLE
Enable AI-managed note operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,10 @@ mvn exec:java
 ## Notes Management
 
 Notes are stored in `notes.json` in the project directory so they persist
-between runs. Use the following commands inside the application:
+between runs. Only one command is required:
 
-- `add-note <title> <content>` – create a new note.
 - `list-notes` – display all notes with their IDs.
-- `delete-note <id>` – remove a note by ID.
-- `summarize-note <id>` – summarize the note's content with AI.
-- `questions-note <id>` – generate questions from the note.
-- `search-notes <query>` – find notes that match the query.
+
+For adding, deleting, searching or summarizing notes, simply ask Jenius in
+natural language and the assistant will use its built-in functions to manage
+the notes for you.

--- a/src/main/java/model/ConversationHistory.java
+++ b/src/main/java/model/ConversationHistory.java
@@ -17,8 +17,9 @@ public class ConversationHistory {
         Ensure all responses do not include the prefix ‘Jenius:’.
 
         [TOOL USAGE]
-        You have access to functions to summarize files and generate questions.
-        If a user's request can be fulfilled by a function (e.g., they mention a file path or ask to summarize), you MUST use that function.
+        You have access to functions to manage notes (add, delete, summarize, search),
+        as well as to summarize files and generate questions.
+        If a user's request can be fulfilled by a function (for example they ask to add a note or summarize content), you MUST use that function.
         Prioritize using a function over giving a conversational answer for tasks that match a tool's capability.
         
         Below is the chat history:\n""";


### PR DESCRIPTION
## Summary
- hand off note management to the AI
- update README docs for new workflow
- inject `NotesManager` into `GenAIModel`
- register note functions and handle them in `executeFunction`
- clarify tool usage instructions

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_b_687664d34ccc8329b66d04032767c875