### PR TITLE
Add command line note creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Or the application using ```run.bat``` file.
 ## Notes Management
 
 Notes are stored in `notes.json` in the project directory so they persist
-between runs. Only one command is required:
+between runs. Use the following commands:
 
 - `list-notes` – display all notes with their IDs.
+- `add-note "title"|"content"` – add a new note directly from the command line.
 
-For adding, deleting, searching or summarizing notes, simply ask Jenius in
-natural language and the assistant will use its built-in functions to manage
-the notes for you.
+Other note actions like deleting or summarizing can still be requested in
+natural language and the assistant will call the appropriate functions for you.

--- a/src/main/java/controller/JeniusController.java
+++ b/src/main/java/controller/JeniusController.java
@@ -49,10 +49,25 @@ public class JeniusController {
         try {
             String normalized = normalize(input).toLowerCase();
 
-            // Note management is handled via AI function calling.
+            // Note management commands
 
             if (normalized.equals("list-notes")) {
                 view.displayNotes(notesManager.getNotes());
+                return;
+            }
+
+            if (normalized.startsWith("add-note")) {
+                String args = input.substring(input.toLowerCase().indexOf("add-note") + 8).trim();
+                String[] parts = args.split("\\|", 2);
+                if (parts.length < 2) {
+                    view.displayError("Invalid add-note format. Use add-note \"title\"|\"content\"");
+                    return;
+                }
+                String title = parts[0].trim().replaceAll("^\"|\"$", "");
+                String content = parts[1].trim().replaceAll("^\"|\"$", "");
+                notesManager.addNote(title, content);
+                String result = "Note added";
+                view.displayResponse(result);
                 return;
             }
 


### PR DESCRIPTION
## Summary
- allow adding notes via a direct `add-note` command
- document the new command in the README

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6876936927ec8329901862112c7e51bc